### PR TITLE
Fix path method

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -23,7 +23,7 @@ action :clean do
 
   # Walk the resource collection to find resources that appear to be
   # contained by the managed_directory.  This depends on the resource's
-  # name attribute containing the full path to the file.
+  # path attribute containing the full path to the file.
   managed_files = run_context.resource_collection
                              .all_resources
                              .select { |r| r.respond_to? :path }

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -24,8 +24,11 @@ action :clean do
   # Walk the resource collection to find resources that appear to be
   # contained by the managed_directory.  This depends on the resource's
   # name attribute containing the full path to the file.
-  managed_files = run_context.resource_collection.all_resources.map { |r|
-    r.name.to_s if r.name.to_s.start_with?("#{new_resource.path}/")
+  managed_files = run_context.resource_collection
+                             .all_resources
+                             .select { |r| r.respond_to? :path }
+                             .map { |r|
+    r.path if r.path.start_with?("#{new_resource.path}/")
   }.compact
 
   # Remove any contents that appear to be unmanaged.

--- a/recipes/test.rb
+++ b/recipes/test.rb
@@ -34,5 +34,12 @@ file "#{testdir}/b" do
   action :touch
 end
 
+# Create a File resource for 'd'
+# by using the `path` method.
+file "#{testdir}/e" do
+  path "#{testdir}/d"  
+  action :touch
+end
+
 # At the end of a Chef run containing this recipe, /tmp/foo should contain
 # files "a" and "b" only.  File "c" will have been removed.

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -9,8 +9,13 @@ describe 'the test recipe example' do
     Dir.stub(:glob).and_call_original
   }
   it 'should remove file c' do
-    Dir.should_receive(:glob).with("/tmp/foo/*").and_return(["/tmp/foo/a","/tmp/foo/b","/tmp/foo/c"])
+    Dir.should_receive(:glob).with("/tmp/foo/*").and_return(["/tmp/foo/a","/tmp/foo/b","/tmp/foo/c","/tmp/foo/d"])
     expect(chef_run).to delete_file "/tmp/foo/c"
+  end
+
+  it 'should not remove file d' do
+    Dir.should_receive(:glob).with("/tmp/foo/*").and_return(["/tmp/foo/a","/tmp/foo/b","/tmp/foo/d"])
+    expect(chef_run).not_to delete_file "/tmp/foo/d"
   end
 end
 


### PR DESCRIPTION
Hi there.

Looking with interest at the managed_directory resource, I noticed a small bug wrt. file resources that use `path` instead of `name`.  Although this might be uncommon, it nonetheless is possible to have a resource like this:

```ruby
file "#{testdir}/e" do
  path "#{testdir}/d"
  action :touch
end
```

or even this

```ruby
log "#{testdir}/e" do
  message "hi there, i'm not a file"
  action :touch
end
```

....so looking for and at the `path` attribute seems like the right thing to do, IMHO.