### PR TITLE
Bug fix for cleaning subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ This file is used to list changes made in each version of the managed_directory 
 
 UNRELEASED
 ----------
+- Fixed bug where attempting to remove a directory with contents from the
+	managed_directory would cause chef-client to abort.
+	- Added contents to subdirectories to test setup to trigger bug
+	- Replaced `directory` resource in the provider with a `ruby_block` call to
+		`FileUtils.remove_dir()` in order to cleanly recursively delete a directory.
+	- Added `force_directories` attribute to allow `FileUtils.remove_dir()` to
+		remove the directory even if there are open files. Defaults to `false`
+	- Updated tests to reflect change from `directory` to `ruby_block`
+
+v0.2.0
+------
 - Added cleaning of subdirectories
 - Added separate handling of links, which were formerly handled by the file
 	resource, as managing links via file resources is deprecated
@@ -18,15 +29,11 @@ UNRELEASED
 - Updated README.md for new behaviors
 - Added ChefSpec matchers for test-ability
 
-0.1.0
------
+v0.1.0
+------
 - add chefspec tests
 - FIX don't blow up when resource names are symbols
 	- Thanks to Mark Friedgan (hubrix) for this fix.
-
-0.0.1
------
-	initial release
 
 - - -
 Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,15 @@ This file is used to list changes made in each version of the managed_directory 
 
 UNRELEASED
 ----------
-- Fixed bug where attempting to remove a directory with contents from the
-	managed_directory would cause chef-client to abort.
-	- Added contents to subdirectories to test setup to trigger bug
-	- Replaced `directory` resource in the provider with a `ruby_block` call to
-		`FileUtils.remove_dir()` in order to cleanly recursively delete a directory.
-	- Added `force_directories` attribute to allow `FileUtils.remove_dir()` to
-		remove the directory even if there are open files. Defaults to `false`
-	- Updated tests to reflect change from `directory` to `ruby_block`
+Fixed bug where attempting to remove a directory with contents from the
+managed_directory would cause chef-client to abort.
+
+- Added contents to subdirectories to test setup to trigger bug
+- Replaced `directory` resource in the provider with a `ruby_block` call to
+	`FileUtils.remove_dir()` in order to cleanly recursively delete a directory.
+- Added `force_directories` attribute to allow `FileUtils.remove_dir()` to
+	remove the directory even if there are open files. Defaults to `false`
+- Updated tests to reflect change from `directory` to `ruby_block`
 
 v0.2.0
 ------

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -37,7 +37,7 @@ action :clean do
       # Using a ruby_block because directory won't succeed if there are any
       # files or subdirectories inside the directory. FileUtils.remove_dir()
       # will do so recursively.
-      ruby_block "recursively delete directory #{e}" do
+      ruby_block "delete directory #{e}" do
         block do
           require 'fileutils'
           Chef::Log.info "Removing unmanaged directory in #{new_resource.path}: #{e}"

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -28,6 +28,8 @@ action :clean do
     r.name.to_s if r.name.to_s.start_with?("#{new_resource.path}/")
   end.compact
 
+  force_directories = new_resource.force_directories
+
   # Remove any contents that appear to be unmanaged.
   entries_to_remove = directory_contents - managed_entries
   entries_to_remove.each do |e|

--- a/recipes/t_resource_name_symbol.rb
+++ b/recipes/t_resource_name_symbol.rb
@@ -4,8 +4,15 @@
 #
 # used by chefspec
 
+testdir = '/tmp/baz'
+
+# Create the directory for our test files, during the compile phase.
+directory testdir do
+  action :nothing
+end.run_action(:create)
+
 # Define the managed_directory
-managed_directory '/tmp/foo' do
+managed_directory testdir do
   action :clean
 end
 

--- a/recipes/test.rb
+++ b/recipes/test.rb
@@ -13,10 +13,14 @@ directory testdir do
 end.run_action(:create)
 
 # 2. Put some files in it, without using Chef, before convergence
-# %w{a b c}.each do |f|
-#   ::File.new("#{testdir}/#{f}", "w+") unless ::File.exist?("#{testdir}/#{f}")
-# end
-# ::File.symlink("#{testdir}/b", "#{testdir}/b_link") unless ::File.exist?("#{testdir}/b_link")
+unless defined?(ChefSpec)
+  %w(a b c d e).each do |f|
+    Chef::Log.warn("Creating test file #{testdir}/#{f}")
+    ::File.new("#{testdir}/#{f}", 'w+') unless ::File.exist?("#{testdir}/#{f}")
+  end
+  Chef::Log.warn("Creating test symlink #{testdir}/b_link to #{testdir}/b")
+  ::File.symlink("#{testdir}/b", "#{testdir}/b_link") unless ::File.exist?("#{testdir}/b_link")
+end
 
 # Create a File resource for 'a'
 file "#{testdir}/a" do
@@ -41,6 +45,13 @@ file "#{testdir}/b" do
   action :touch
 end
 
+# Create a File resource for 'd' by using the `path` method and
+# having the resource name itself not match our managed_directory path.
+file 'named_file_resource' do
+  path "#{testdir}/d"
+  action :touch
+end
+
 # At the end of a Chef run containing this recipe, /tmp/foo should contain
-# files "a" and "b" and symbolic link "a_link".  File "c" and symlink "b_link"
-# will have been removed.
+# files "a", "b", and "d" and symbolic link "a_link".  File "c" and symlink
+# "b_link" will have been removed.

--- a/recipes/test_directories.rb
+++ b/recipes/test_directories.rb
@@ -13,9 +13,17 @@ directory testdir do
 end.run_action(:create)
 
 # 2. Put some files in it, without using Chef, before convergence
-# %w{a b c}.each do |d|
-#   ::Dir.mkdir("#{testdir}/#{d}_dir") unless ::Dir.exist?("#{testdir}/#{d}_dir")
-# end
+unless defined?(ChefSpec)
+  %w(a b c).each do |d|
+    Chef::Log.warn("Creating test directory #{testdir}/#{d}_dir")
+    ::Dir.mkdir("#{testdir}/#{d}_dir") unless ::Dir.exist?("#{testdir}/#{d}_dir")
+  end
+  # stuff some files into c_dir
+  %w(a b c).each do |f|
+    Chef::Log.warn("Creating test file #{testdir}/c_dir/#{f}")
+    ::File.new("#{testdir}/c_dir/#{f}", 'w+') unless ::File.exist?("#{testdir}/c_dir/#{f}")
+  end
+end
 
 # Create a directory resource for 'a_dir'
 directory "#{testdir}/a_dir" do

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -36,3 +36,6 @@ attribute :clean_links, :kind_of => [TrueClass, FalseClass], :default => true
 
 # Should we clean subdirectories out of our managed directory? Default, no
 attribute :clean_directories, :kind_of => [TrueClass, FalseClass], :default => false
+
+# Should we force directory removal, or fail if there are open files?
+attribute :force_directories, :kind_of => [TrueClass, FalseClass], :default => false

--- a/spec/unit/recipes/test_directories_spec.rb
+++ b/spec/unit/recipes/test_directories_spec.rb
@@ -48,15 +48,18 @@ describe 'managed_directory::test_directories' do
     end
 
     it 'should not remove directory a_dir' do
-      expect(chef_run).to_not delete_directory('/tmp/bar/a_dir')
+      # expect(chef_run).to_not delete_directory('/tmp/bar/a_dir')
+      expect(chef_run).to_not run_ruby_block('delete directory /tmp/bar/a_dir')
     end
 
     it 'should not remove directory b_dir' do
-      expect(chef_run).to_not delete_directory('/tmp/bar/b_dir')
+      # expect(chef_run).to_not delete_directory('/tmp/bar/b_dir')
+      expect(chef_run).to_not run_ruby_block('delete directory /tmp/bar/b_dir')
     end
 
     it 'should remove directory c_dir' do
-      expect(chef_run).to delete_directory('/tmp/bar/c_dir')
+      # expect(chef_run).to delete_directory('/tmp/bar/c_dir')
+      expect(chef_run).to run_ruby_block('delete directory /tmp/bar/c_dir')
     end
   end
 end


### PR DESCRIPTION
Fixed bug where attempting to remove a directory with contents from the
managed_directory would cause chef-client to abort.

- Added contents to subdirectories to test setup to trigger bug
- Replaced `directory` resource in the provider with a `ruby_block` call to
	`FileUtils.remove_dir()` in order to cleanly recursively delete a directory.
- Added `force_directories` attribute to allow `FileUtils.remove_dir()` to
	remove the directory even if there are open files. Defaults to `false`
- Updated tests to reflect change from `directory` to `ruby_block`

Resolves #9 