### PR TITLE
Find resources by path (updated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ MANAGED_DIRECTORY CHANGELOG
 
 This file is used to list changes made in each version of the managed_directory cookbook.
 
+UNRELEASED
+------
+- Update provider to examine resources based on their path, rather than
+	the resource names. This accounts for resources being named something other
+	than their path.
+
 v0.2.1
 ------
 - Fix bug for subdirectories when clean_directories is false. This would cause

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ UNRELEASED
 ------
 - Update provider to examine resources based on their path, rather than
 	the resource names. This accounts for resources being named something other
-	than their path. Thanks to @srenatus for this one!
+	than their path. Thanks to [srenatus](https://github.com/srenatus)!
 
 v0.2.1
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ UNRELEASED
 ------
 - Update provider to examine resources based on their path, rather than
 	the resource names. This accounts for resources being named something other
-	than their path.
+	than their path. Thanks to @srenatus for this one!
 
 v0.2.1
 ------

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Caveats
 
 ```ruby
 managed_directory '/etc/yum.repos.d' do
-  action	:nothing
+  action :nothing
   clean_directories true
 end
 

--- a/README.md
+++ b/README.md
@@ -80,13 +80,29 @@ Caveats
    (eg, from within a `ruby_block` or LWRP later in the run list) will
    be incorrectly identified as "unmanaged", and then deleted.  They
    will be recreated later in the run, but this creates a window where
-   the file is missing.
+   the file is missing. For a work-around, you can define the
+   `managed_directory` with `action :none` and use another resource to notify
+   it `:delayed`. For example, if you're using the `yum` cookbook to manage
+   all your repositories, you might do something like:
+
+```ruby
+managed_directory '/etc/yum.repos.d' do
+  action	:nothing
+  clean_directories true
+end
+
+ruby_block 'delayed_managed_directory /etc/yum.repos.d' do
+  block { true }
+  notifies	:clean, 'managed_directory[/etc/yum.repos.d]', :delayed
+end
+```
 
 
 License and Author
 ==================
 
 Authors:
+
 - Zachary Stevens ([zts](https://github.com/zts))
 - Gregory Ruiz-Ade ([gkra](https://github.com/gkra))
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -22,11 +22,17 @@ action :clean do
   directory_contents = ::Dir.glob("#{new_resource.path}/*")
 
   # Walk the resource collection to find resources that appear to be
-  # contained by the managed_directory.  This depends on the resource's
-  # name attribute containing the full path to the file.
-  managed_entries = run_context.resource_collection.all_resources.map do |r|
-    r.name.to_s if r.name.to_s.start_with?("#{new_resource.path}/")
-  end.compact
+  # contained by the managed_directory.
+  
+  # Pass 1: Find all the resources which have a path attribute
+  path_resources = run_context.resource_collection.all_resources.select do |r|
+    r.respond_to?(:path)
+  end
+
+  # Pass 2: See if any of the resources we found have a path that matches ours
+  managed_entries = path_resources.map do |r|
+    r.path if r.path.start_with?("#{new_resource.path}/")
+  end
 
   # Remove any contents that appear to be unmanaged.
   entries_to_remove = directory_contents - managed_entries

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -23,7 +23,10 @@ action :clean do
 
   # Walk the resource collection to find resources that appear to be
   # contained by the managed_directory.
-  
+  # Select resources by path, rather than by name, to account for resources
+  # whose name and path differ, so that we can manage them properly.
+  # Thanks to @srenatus for the contribution!
+
   # Pass 1: Find all the resources which have a path attribute
   path_resources = run_context.resource_collection.all_resources.select do |r|
     r.respond_to?(:path)

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -35,7 +35,7 @@ action :clean do
   # Pass 2: See if any of the resources we found have a path that matches ours
   managed_entries = path_resources.map do |r|
     r.path if r.path.start_with?("#{new_resource.path}/")
-  end
+  end.compact
 
   # Remove any contents that appear to be unmanaged.
   entries_to_remove = directory_contents - managed_entries

--- a/spec/unit/recipes/test_spec.rb
+++ b/spec/unit/recipes/test_spec.rb
@@ -26,7 +26,9 @@ describe 'managed_directory::test' do
         '/tmp/foo/b',
         '/tmp/foo/b_link',
         '/tmp/foo/c',
-        '/tmp/foo/c_dir'
+        '/tmp/foo/c_dir',
+        '/tmp/foo/d',
+        '/tmp/foo/e'
       ]
       allow(Dir).to receive(:glob).and_call_original
       allow(Dir).to receive(:glob).with('/tmp/foo/*').and_return(testdir_contents)
@@ -59,6 +61,14 @@ describe 'managed_directory::test' do
 
     it 'should remove file c' do
       expect(chef_run).to delete_file('/tmp/foo/c')
+    end
+
+    it 'should not remove file d' do
+      expect(chef_run).to_not delete_file('/tmp/foo/d')
+    end
+
+    it 'should remove file e' do
+      expect(chef_run).to delete_file('/tmp/foo/e')
     end
 
     # It shouldn't remove c_dir because in this test we haven't told

--- a/test/integration/default/serverspec/test_spec.rb
+++ b/test/integration/default/serverspec/test_spec.rb
@@ -34,11 +34,10 @@ describe 'managed_directory::test' do
     describe file('/tmp/foo/e') do
       it { should_not be_file }
     end
-    
+
     describe file('/tmp/foo/c_dir') do
       it { should be_directory }
     end
-
   elsif %w(windows).include?(os[:family])
     # Tests for Windows
     it 'does something in windows' do

--- a/test/integration/default/serverspec/test_spec.rb
+++ b/test/integration/default/serverspec/test_spec.rb
@@ -31,6 +31,10 @@ describe 'managed_directory::test' do
       it { should be_file }
     end
 
+    describe file('/tmp/foo/e') do
+      it { should_not be_file }
+    end
+    
     describe file('/tmp/foo/c_dir') do
       it { should be_directory }
     end


### PR DESCRIPTION
This PR supersedes #8.

Find resources by `path` instead of by name, to catch any resources which happen to have names not matching the `managed_directory` resource name/path, but nonetheless match by path.

Resolves #4 
