### PR TITLE
add line for Chef 16.2+ compat, also pass newer cookstyle tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,10 @@
-AlignParameters:
+Chef/Modernize/DefinesChefSpecMatchers:
   Enabled: false
 ClassAndModuleChildren:
   Enabled: false
 Encoding:
   Enabled: false
-Style/SpaceBeforeFirstArg:
+Layout/ParameterAlignment:
   Enabled: false
 LineLength:
   Max: 200

--- a/recipes/t_basic.rb
+++ b/recipes/t_basic.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: managed_directory
+# Cookbook:: managed_directory
 # Recipe:: t_basic
 #
 # used by chefspec

--- a/recipes/t_basic_reversed.rb
+++ b/recipes/t_basic_reversed.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: managed_directory
+# Cookbook:: managed_directory
 # Recipe:: t_basic_reversed
 #
 # used by chefspec

--- a/recipes/t_resource_name_symbol.rb
+++ b/recipes/t_resource_name_symbol.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: managed_directory
+# Cookbook:: managed_directory
 # Recipe:: t_resource_name_symbol
 #
 # used by chefspec

--- a/recipes/test.rb
+++ b/recipes/test.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: managed_directory
+# Cookbook:: managed_directory
 # Recipe:: test
 #
 # A simple demonstration of managed_directory, also used by chefspec.

--- a/recipes/test_directories.rb
+++ b/recipes/test_directories.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: managed_directory
+# Cookbook:: managed_directory
 # Recipe:: test
 #
 # A simple demonstration of managed_directory, also used by chefspec.

--- a/resources/managed_directory.rb
+++ b/resources/managed_directory.rb
@@ -1,9 +1,9 @@
 #
-# Cookbook Name:: managed_directory
+# Cookbook:: managed_directory
 # Resource:: managed_directory
 #
-# Copyright 2012, Zachary Stevens (original LWRP)
-# Copyright 2017, Heig Gregorian (custom resource)
+# Copyright:: 2012, Zachary Stevens (original LWRP)
+# Copyright:: 2017, Heig Gregorian (custom resource)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #
 
 resource_name :managed_directory
+provides :managed_directory
 
 # Implement a single action, and make that the default.
 default_action :clean
@@ -27,13 +28,13 @@ default_action :clean
 property :path, String, name_property: true
 
 # Should we clean files out of our managed directory? Default, yes
-property :clean_files, [TrueClass, FalseClass], required: false, default: true
+property :clean_files, [true, false], required: false, default: true
 
 # Should we clean links out of our managed directory? Default, yes
-property :clean_links, [TrueClass, FalseClass], required: false, default: true
+property :clean_links, [true, false], required: false, default: true
 
 # Should we clean subdirectories out of our managed directory? Default, no
-property :clean_directories, [TrueClass, FalseClass], required: false, default: false
+property :clean_directories, [true, false], required: false, default: false
 
 action :clean do
   # get the contents of the managed_directory on disk


### PR DESCRIPTION
Two updates, one of them important:

1. Add a new line to the resource def so that this cookbook works in Chef 16.2+ (why Chef could not have simply included a backwards-compatible default is beyond me, to be honest)
2. Minor syntax/comment updates so that the current version of cookstyle is happy with managed_directory

Tested with Chef 16.13.16, working as expected. (Previously was failing, saying that 'managed_directory' was not defined. See https://discourse.chef.io/t/chef-infra-client-16-2-released/17284)