### PR TITLE
add unified_mode, rubocop ignore for foodcritic

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+Chef/Deprecations/FoodcriticFile:
+  Enabled: false
 Chef/Modernize/DefinesChefSpecMatchers:
   Enabled: false
 ClassAndModuleChildren:

--- a/resources/managed_directory.rb
+++ b/resources/managed_directory.rb
@@ -20,6 +20,7 @@
 
 resource_name :managed_directory
 provides :managed_directory
+unified_mode true if respond_to?(:unified_mode)
 
 # Implement a single action, and make that the default.
 default_action :clean


### PR DESCRIPTION
1. add `unified_mode true` for more recent releases of Chef client
2. tell cookstyle to shaddup about the .foodcritic file